### PR TITLE
fix always returning a  jpeg

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,7 @@ module.exports = function(options) {
         height,
         quality,
         width,
+        format
       })
       res.send(image)
     } catch (e) {


### PR DESCRIPTION
The format is not passed to transform function introduced in the 2017 refactor.  This causes the result to always be the default of jpeg.