### PR TITLE
fix: resolve memory leak in CachedImage

### DIFF
--- a/src/cached-image.test.ts
+++ b/src/cached-image.test.ts
@@ -20,15 +20,15 @@ describe('CachedImage', () => {
     adapter = new ImageAdapterMock()
     cache = new Map()
 
-    cachedImage = new CachedImage(new Keyv({ store: cache }), adapter)
+    cachedImage = new CachedImage(new Keyv({ store: cache }))
   })
 
   describe('fetch()', () => {
     it('stores the image in the cache', async () => {
-      expect(await cachedImage.fetch('abc')).toBeUndefined()
+      expect(await cachedImage.fetch('abc', adapter)).toBeUndefined()
 
       adapter.fetchMock = Buffer.from('foo')
-      expect((await cachedImage.fetch('def'))?.toString()).toBe('foo')
+      expect((await cachedImage.fetch('def', adapter))?.toString()).toBe('foo')
 
       expect(cache).toMatchInlineSnapshot(`
         Map {
@@ -41,7 +41,7 @@ describe('CachedImage', () => {
       // @ts-ignore
       await cachedImage.cache.set('image:foo', 'bar')
 
-      expect((await cachedImage.fetch('foo'))?.toString()).toBe('bar')
+      expect((await cachedImage.fetch('foo', adapter))?.toString()).toBe('bar')
     })
   })
 })

--- a/src/cached-image.ts
+++ b/src/cached-image.ts
@@ -1,16 +1,15 @@
 import Keyv from 'keyv'
 import { ImageAdapter } from './interfaces'
 import { getLogger } from './logger'
+import { singleton } from 'tsyringe'
 
+@singleton()
 export class CachedImage {
   log = getLogger('cached-image')
 
-  constructor(
-    private readonly cache: Keyv<Buffer>,
-    private readonly adapter: ImageAdapter,
-  ) {}
+  constructor(private readonly cache: Keyv<Buffer>) {}
 
-  async fetch(id: string): Promise<Buffer | undefined> {
+  async fetch(id: string, adapter: ImageAdapter): Promise<Buffer | undefined> {
     const cacheKey = `image:${id}`
 
     let image = await this.cache.get(cacheKey)
@@ -20,7 +19,7 @@ export class CachedImage {
       return image
     }
 
-    image = await this.adapter.fetch(id)
+    image = await adapter.fetch(id)
 
     if (image) {
       this.log(`Caching original image ${id} ...`)

--- a/src/transformer.service.test.ts
+++ b/src/transformer.service.test.ts
@@ -3,6 +3,7 @@ import { container } from 'tsyringe'
 import { ImageAdapter } from './interfaces'
 import { ObjectHash } from './object-hash.service'
 import { Transformer } from './transformer.service'
+import { CachedImage } from './cached-image'
 
 class ImageMockAdapter implements ImageAdapter {
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -15,7 +16,12 @@ describe('Transformer', () => {
   let transformer: Transformer
 
   beforeEach(() => {
-    transformer = new Transformer(container.resolve(ObjectHash), new Keyv())
+    const cache = new Keyv()
+    transformer = new Transformer(
+      container.resolve(ObjectHash),
+      cache,
+      new CachedImage(cache),
+    )
   })
 
   describe('getCropDimensions()', () => {

--- a/src/transformer.service.ts
+++ b/src/transformer.service.ts
@@ -17,6 +17,7 @@ export class Transformer {
   constructor(
     private readonly objectHasher: ObjectHash,
     private readonly cache: Keyv<Result>,
+    private readonly cachedOriginalImage: CachedImage,
   ) {}
 
   getCropDimensions(maxSize: number, width: number, height?: number): number[] {
@@ -59,11 +60,7 @@ export class Transformer {
 
     this.log(`Resizing ${id} with options:`, JSON.stringify(options))
 
-    const cachedOriginalImage = new CachedImage(
-      this.cache as Keyv,
-      imageAdapter,
-    )
-    const originalImage = await cachedOriginalImage.fetch(id)
+    const originalImage = await this.cachedOriginalImage.fetch(id, imageAdapter)
 
     if (!originalImage) {
       return {


### PR DESCRIPTION
Currently, the CachedImage class is repeatedly constructed by the
Transformer service. This would be okay, except that the constructor for
CacheImage called getLogger(), which ultimately invokes createNewDebug
inside the "debug" package. This creates new debugger instance which is
kept in a list of instances by the "debug" package and is thus never
removed. Consequently, everytime an image is transformed there is a
small leak for the new debug instance.

It looked like CachedImage was trying to be a singleton service. It
appeared that it was not such a service because Transformer took the
ImageAdapter as a function level parameter and needed to pass into the
CachedImage. I changed CachedImage to also take ImageAdapter as a
parameter and CachedImage into a singleton service thus avoiding the
constant reconstruction and memory leak.