### PR TITLE
Change preinstall pnpm to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,8 +76,7 @@
     "lint": "eslint --cache .",
     "test": "jest",
     "ci:test": "jest --coverage",
-    "preinstall": "npx only-allow pnpm",
-    "prepare": "husky install"
+    "prepare": "husky install && npx only-allow pnpm"
   },
   "engines": {
     "node": ">= 12.0.0"


### PR DESCRIPTION
Thank you for the great work here.
preinstall breaks installation for anyone without pnpm installed. changing to prepare will be not be trigged in the installation of the library.
